### PR TITLE
unpin gt4py from a specific commit, let it roll forward nightly with …

### DIFF
--- a/docker/Dockerfile.build_environment
+++ b/docker/Dockerfile.build_environment
@@ -14,7 +14,7 @@ RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10
 
 FROM fv3ser-environment as fv3ser-install
 RUN pip install --no-cache-dir scikit-build && \
-    git clone https://github.com/MeteoSwiss-APN/dawn.git /usr/src/dawn && \
+    git clone --depth 1 https://github.com/MeteoSwiss-APN/dawn.git /usr/src/dawn && \
     pip install --no-cache-dir /usr/src/dawn/dawn
 
 RUN git clone --depth 1 https://github.com/GridTools/gt4py.git /usr/src/gt4py &&  \


### PR DESCRIPTION
…master. The commit that had been pinned was actually breaking, and the fv3ser-install image hasn't been updated in quite awhile. Let's unblock jenkins work by bringing gt4py master back into the CI fold. 
The was tested locally (using PULL=False). 