### PR TITLE
Stencil fixes for GridTools backends

### DIFF
--- a/fv3/stencils/del2cubed.py
+++ b/fv3/stencils/del2cubed.py
@@ -31,7 +31,7 @@ def compute_meridional_flux(flux: sd, A_in: sd, del_term: sd):
 ## Q update stencil
 ##------------------
 @utils.stencil()
-def update_q(q: sd, cd: float, rarea: sd, fx: sd, fy: sd):
+def update_q(q: sd, rarea: sd, fx: sd, fy: sd, cd: float):
     with computation(PARALLEL), interval(...):
         q = q + cd * rarea * (fx - fx[1, 0, 0] + fy - fy[0, 1, 0])
 
@@ -39,13 +39,15 @@ def update_q(q: sd, cd: float, rarea: sd, fx: sd, fy: sd):
 @utils.stencil()
 def copy_row(A: sd):
     with computation(PARALLEL), interval(...):
-        A = A[1, 0, 0]
+        A0 = A
+        A = A0[1, 0, 0]
 
 
 @utils.stencil()
 def copy_column(A: sd):
     with computation(PARALLEL), interval(...):
-        A = A[0, 1, 0]
+        A0 = A
+        A = A0[0, 1, 0]
 
 
 ##
@@ -126,4 +128,4 @@ def compute(qdel, nmax, cd, km):
 
         # Update q values
         ny = grid.njc + 2 * nt  # (grid.je+nt) - (grid.js-nt) + 1
-        update_q(qdel, cd, grid.rarea, fx, fy, origin=origin, domain=(nx, ny, km))
+        update_q(qdel, grid.rarea, fx, fy, cd, origin=origin, domain=(nx, ny, km))

--- a/fv3/stencils/nh_p_grad.py
+++ b/fv3/stencils/nh_p_grad.py
@@ -28,7 +28,7 @@ def CalcWk(pk: sd, wk: sd):
 
 
 @utils.stencil()
-def CalcU(u: sd, du: sd, dt: float, wk: sd, wk1: sd, gz: sd, pk3: sd, pp: sd, rdx: sd):
+def CalcU(u: sd, du: sd, wk: sd, wk1: sd, gz: sd, pk3: sd, pp: sd, rdx: sd, dt: float):
     with computation(PARALLEL), interval(...):
         # hydrostatic contribution
         du = (
@@ -53,7 +53,7 @@ def CalcU(u: sd, du: sd, dt: float, wk: sd, wk1: sd, gz: sd, pk3: sd, pp: sd, rd
 
 
 @utils.stencil()
-def CalcV(v: sd, dv: sd, dt: float, wk: sd, wk1: sd, gz: sd, pk3: sd, pp: sd, rdy: sd):
+def CalcV(v: sd, dv: sd, wk: sd, wk1: sd, gz: sd, pk3: sd, pp: sd, rdy: sd, dt: float):
     with computation(PARALLEL), interval(...):
         # hydrostatic contribution
         dv[0, 0, 0] = (
@@ -98,8 +98,6 @@ def compute(u, v, pp, gz, pk3, delp, dt, ptop, akap):
     a2b_ord4.compute(pp, wk1, kstart=1, nk=grid.npz, replace=True)
     a2b_ord4.compute(pk3, wk1, kstart=1, nk=grid.npz, replace=True)
 
-    assert pp[3, 3, 0] == 0.0
-    assert pk3[3, 3, 0] == top_value
     a2b_ord4.compute(gz, wk1, kstart=0, nk=grid.npz + 1, replace=True)
     a2b_ord4.compute(delp, wk1)
 
@@ -110,13 +108,13 @@ def compute(u, v, pp, gz, pk3, delp, dt, ptop, akap):
     CalcU(
         u,
         du,
-        dt,
         wk,
         wk1,
         gz,
         pk3,
         pp,
         grid.rdx,
+        dt,
         origin=orig,
         domain=(grid.nic, grid.njc + 1, grid.npz),
     )
@@ -126,13 +124,13 @@ def compute(u, v, pp, gz, pk3, delp, dt, ptop, akap):
     CalcV(
         v,
         dv,
-        dt,
         wk,
         wk1,
         gz,
         pk3,
         pp,
         grid.rdy,
+        dt,
         origin=orig,
         domain=(grid.nic + 1, grid.njc, grid.npz),
     )


### PR DESCRIPTION
This PR applies changes two changes to the `A2B_Ord4`, `Del2Cubed`, and `NH_P_Grad` stencils to be consistent with the `GridTools` backends.

1. Introduce temporaries when a field is read on the right hand side of an assignment statement, and written to on the left hand side.
2. Ensure that all fields are defined first in the stencil parameter list, and scalar variables follow them.