### PR TITLE
Fix error in parallel test output type

### DIFF
--- a/tests/translate/parallel_translate.py
+++ b/tests/translate/parallel_translate.py
@@ -168,8 +168,12 @@ class ParallelTranslate2Py(ParallelTranslate):
         inputs["comm"] = communicator
         inputs = self.state_from_inputs(inputs)
         result = self._base.compute_from_storage(inputs)
-        quantity_result = self.outputs_from_state(inputs)
+        quantity_result = self.outputs_from_state(result)
         result.update(quantity_result)
+        for name, data in result.items():
+            if isinstance(data, fv3util.Quantity):
+                result[name] = data.storage
+        result.update(self._base.slice_output(result))
         return result
 
     def compute_sequential(self, a, b):

--- a/tests/translate/translate.py
+++ b/tests/translate/translate.py
@@ -32,14 +32,14 @@ class TranslateFortranData2Py:
 
     def compute(self, inputs):
         self.make_storage_data_input_vars(inputs)
-        return self.compute_from_storage(inputs)
+        return self.slice_output(self.compute_from_storage(inputs))
 
     # assume inputs already has been turned into gt4py storages (or Quantities)
     def compute_from_storage(self, inputs):
         outputs = self.compute_func(**inputs)
         if outputs is not None:
             inputs.update(outputs)
-        return self.slice_output(inputs)
+        return inputs
 
     def column_split_compute(self, inputs, info_mapping):
         column_info = {}


### PR DESCRIPTION
The BaseSlicing parallel class converts quantities back to storages for comparison, but was using the data from the 'standard' name, which didn't get altered. 