### PR TITLE
Add splitters as grid property

### DIFF
--- a/fv3core/utils/grid.py
+++ b/fv3core/utils/grid.py
@@ -84,6 +84,15 @@ class Grid:
             )
         return self._quantity_factory
 
+    @property
+    def splitters(self):
+        return {
+            "i_start": self.is_ - self.global_is,
+            "i_end": self.npx + self.halo - 2 - self.global_is,
+            "j_start": self.js - self.global_js,
+            "j_end": self.npy + self.halo - 2 - self.global_js,
+        }
+
     def make_quantity(
         self,
         array,


### PR DESCRIPTION
We will reference this in all the stencil calls that use splitters.