### PR TITLE
Update `Neg_Adj3` to work with CUDA backends

### DIFF
--- a/fv3core/stencils/neg_adj3.py
+++ b/fv3core/stencils/neg_adj3.py
@@ -327,7 +327,7 @@ def compute(qvapor, qliquid, qrain, qsnow, qice, qgraupel, qcld, pt, delp, delz,
     # fix_water_vapor_bottom(grid, qvapor, delp)
     upper_fix = utils.make_storage_from_shape(qvapor.shape, origin=(0, 0, 0))
     lower_fix = utils.make_storage_from_shape(qvapor.shape, origin=(0, 0, 0))
-    bot_dp = delp.data[:, :, grid.npz - 1]
+    bot_dp = delp[:, :, grid.npz - 1]
     full_bot_arr = utils.repeat(bot_dp[:, :, np.newaxis], k_ext + 1, axis=2)
     dp_bot = utils.make_storage_data(full_bot_arr, full_bot_arr.shape)
     fix_water_vapor_down(
@@ -339,7 +339,7 @@ def compute(qvapor, qliquid, qrain, qsnow, qice, qgraupel, qcld, pt, delp, delz,
         origin=grid.compute_origin(),
         domain=grid.domain_shape_compute(),
     )
-    qvapor.data[:, :, grid.npz] = upper_fix.data[:, :, 0]
+    qvapor[:, :, grid.npz] = upper_fix[:, :, 0]
     fix_neg_cloud(
         delp, qcld, origin=grid.compute_origin(), domain=grid.domain_shape_compute()
     )


### PR DESCRIPTION
This PR removes the `.data` references in the `Neg_Adj3` stencils so the code will work for CPU or GPU storages.