### PR TITLE
Fix bug introduced in #107

### DIFF
--- a/fv3core/utils/gt4py_utils.py
+++ b/fv3core/utils/gt4py_utils.py
@@ -70,7 +70,7 @@ def stencil(**stencil_kwargs) -> Callable[..., None]:
             # This uses the module-level globals backend and rebuild (defined above)
             key = (backend, rebuild)
             if key not in stencils:
-                # add globals to stencil_kwargs
+                # Add globals to stencil_kwargs
                 stencil_kwargs["rebuild"] = rebuild
                 stencil_kwargs["backend"] = backend
                 # Generate stencil


### PR DESCRIPTION
Copy `stencil_kwargs` to `build_kwargs` so that `rebuild` and `backend` are not in the dict on the next time through the function.