### PR TITLE
Fix sim1_solver sporadic error

### DIFF
--- a/fv3core/stencils/sim1_solver.py
+++ b/fv3core/stencils/sim1_solver.py
@@ -37,7 +37,7 @@ def sim1_solver(
         with interval(1, None):
             wsr_top = wsr_top[0, 0, -1]
 
-    with computation(PARALLEL), interval(...):
+    with computation(PARALLEL), interval(0, -1):
         pe = exp(gm * log(-dm / dz * constants.RDGAS * ptr)) - pm
         w1 = w
     with computation(FORWARD):
@@ -52,7 +52,7 @@ def sim1_solver(
     with computation(FORWARD):
         with interval(0, 1):
             bet = bb
-        with interval(1, None):
+        with interval(1, -1):
             bet = bet[0, 0, -1]
 
     ### stencils: w_solver
@@ -94,7 +94,7 @@ def sim1_solver(
             w = (
                 dm * w1 + dt * (pp[0, 0, 1] - pp) - p1 * wsr_top - aa * w[0, 0, -1]
             ) / bet
-    with computation(BACKWARD), interval(0, -1):
+    with computation(BACKWARD), interval(0, -2):
         w = w - gam[0, 0, 1] * w[0, 0, 1]
     with computation(FORWARD):
         with interval(0, 1):


### PR DESCRIPTION
Set the sim1_solver k bounds so they are not accessing undefined data. This should hopefully stop the Riem_Solver3 tests from randomly failing getting nans in the data at random points. (Also should impact Riem_SolverC, but we haven't seen that one fail). 