### PR TITLE
Add venv for lint step

### DIFF
--- a/.jenkins/actions/lint.sh
+++ b/.jenkins/actions/lint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e -x
-pip3 install -r requirements.txt
-PIP_BIN_DIR=/home/jenkins/.local/bin
-${PIP_BIN_DIR}/pre-commit run --all-files
+env_name=venv-${BUILD_NUMBER:-0}
+python3 -m venv ${env_name}
+. ${env_name}/bin/activate
+pip install -r requirements.txt
+pre-commit run --all-files
+deactivate
 echo $(date) > aggregate


### PR DESCRIPTION
A VM is sometimes used for multiple builds simultaneously, and this ensures they do not step on eachothers' toes.