### PR TITLE
Fix unsafe code in make_storage_from_shape

### DIFF
--- a/fv3core/utils/gt4py_utils.py
+++ b/fv3core/utils/gt4py_utils.py
@@ -4,7 +4,7 @@ import copy
 import functools
 import logging
 import math
-from typing import Callable
+from typing import Callable, Tuple, Union
 
 import gt4py as gt
 import gt4py.gtscript as gtscript
@@ -41,11 +41,17 @@ tracer_variables = [
     "qsgs_tke",
     "qcld",
 ]
+
+# Union of valid data types (from gt4py.gtscript)
+DTypes = Union[bool, np.bool, int, np.int32, np.int64, float, np.float32, np.float64]
+
+
 # 1 indexing to 0 and halos: -2, -1, 0 --> 0, 1,2
 if MPI is not None and MPI.COMM_WORLD.Get_size() > 1:
     gt.config.cache_settings["dir_name"] = ".gt_cache_{:0>6d}".format(
         MPI.COMM_WORLD.Get_rank()
     )
+
 # TODO remove when using quantities throughout model
 def quantity_name(name):
     return name + "_quantity"
@@ -233,8 +239,24 @@ def make_storage_data_from_1d(
     )
 
 
-def make_storage_from_shape(shape, origin, dtype=np.float64):
-    return gt.storage.from_array(
+def make_storage_from_shape(
+    shape: Tuple[int, int, int],
+    origin: Tuple[int, int, int],
+    dtype: DTypes = np.float64,
+    init: bool = True,
+):
+    """Create a new gt4py storage of a given shape.
+
+    Args:
+        shape: Size of the new storage
+        origin: Default origin for gt4py stencil calls
+        dtype: Data type
+        init: If True, initializes the storage to the default value for the type
+
+    Returns:
+        gtscript.Field[dtype]: New storage
+    """
+    storage = gt.storage.from_array(
         data=np.empty(shape, dtype=dtype),
         dtype=dtype,
         backend=backend,
@@ -242,6 +264,10 @@ def make_storage_from_shape(shape, origin, dtype=np.float64):
         shape=shape,
         managed_memory=managed_memory,
     )
+    if init:
+        storage[:] = dtype()
+
+    return storage
 
 
 def storage_dict(st_dict, names, shape, origin):


### PR DESCRIPTION
Also adds `init` flag that allows for uninitialized storage (but not yet used in fv3core).