### PR TITLE
remove the junitxml for parallel tests

### DIFF
--- a/.jenkins/actions/run_parallel_regression_tests.sh
+++ b/.jenkins/actions/run_parallel_regression_tests.sh
@@ -2,7 +2,7 @@
 set -e -x
 BACKEND=$1
 EXPNAME=$2
-ARGS="-v -s -rsx --backend=${BACKEND} "
+ARGS="-v -s -rsx --backend=${BACKEND}"
 export EXPERIMENT=${EXPNAME}
 
 # Set the host data location


### PR DESCRIPTION
The output of parallel tests  are a mess -- intertwined output sometimes creates xml files that causes the jenkins builds to be unstable trying to parse it. We may want to revisit the output of parallel tests, or pipe the stdout of each rank to a different file but as an easy stop gap, let's just remove their creation for now so we aren't constantly checking unstable builds