### PR TITLE
Fix numpy errors in mock parallel tests with CUDA backends

### DIFF
--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -3,7 +3,6 @@
 import contextlib
 import logging
 import os
-import sys
 
 import fv3gfs.util as fv3util
 import numpy as np


### PR DESCRIPTION
This PR fixes numpy array errors in the mock parallel savepoint tests with the CUDA backends by calling the `gt4py_utils.asarray` method on the output data before comparing with the reference data.