### PR TITLE
Import namelist and grid automatically and assert instead of if condition

### DIFF
--- a/fv3core/decorators.py
+++ b/fv3core/decorators.py
@@ -83,6 +83,13 @@ def gtstencil(definition=None, **stencil_kwargs) -> Callable[..., None]:
                 # Add globals to stencil_kwargs
                 stencil_kwargs["rebuild"] = utils.rebuild
                 stencil_kwargs["backend"] = utils.backend
+
+                # Add externals
+                stencil_kwargs["externals"] = {
+                    "namelist": spec.namelist,
+                    "grid": spec.grid,
+                    **stencil_kwargs.get("externals", dict()),
+                }
                 # Generate stencil
                 build_info = {}
                 stencil = gtscript.stencil(build_info=build_info, **stencil_kwargs)(

--- a/fv3core/stencils/vorticitytransport_cgrid.py
+++ b/fv3core/stencils/vorticitytransport_cgrid.py
@@ -22,14 +22,17 @@ def update_zonal_velocity(
     rdxc: sd,
     dt2: float,
 ):
+    from __externals__ import namelist
     from __splitters__ import i_end, i_start
 
     with computation(PARALLEL), interval(...):
+        assert __INLINED(namelist.grid_type < 3)
+        # additional assumption: not __INLINED(spec.grid.nested)
+
         tmp_flux = dt2 * (velocity - velocity_c * cosa) / sina
-        if __INLINED(spec.namelist.grid_type < 3):
-            # additional assumption: not __INLINED(spec.grid.nested)
-            with parallel(region[i_start, :], region[i_end + 1, :]):
-                tmp_flux = dt2 * velocity
+        with parallel(region[i_start, :], region[i_end + 1, :]):
+            tmp_flux = dt2 * velocity
+
         flux = vorticity[0, 0, 0] if tmp_flux > 0.0 else vorticity[0, 1, 0]
         velocity_c = velocity_c + tmp_flux * flux + rdxc * (ke[-1, 0, 0] - ke)
 
@@ -45,14 +48,16 @@ def update_meridional_velocity(
     rdyc: sd,
     dt2: float,
 ):
+    from __externals__ import namelist
     from __splitters__ import j_end, j_start
 
     with computation(PARALLEL), interval(...):
+        assert __INLINED(namelist.grid_type < 3)
+        # additional assumption: not __INLINED(spec.grid.nested)
+
         tmp_flux = dt2 * (velocity - velocity_c * cosa) / sina
-        if __INLINED(spec.namelist.grid_type < 3):
-            # additional assumption: not __INLINED(spec.grid.nested)
-            with parallel(region[:, j_start], region[:, j_end + 1]):
-                tmp_flux = dt2 * velocity
+        with parallel(region[:, j_start], region[:, j_end + 1]):
+            tmp_flux = dt2 * velocity
         flux = vorticity[0, 0, 0] if tmp_flux > 0.0 else vorticity[1, 0, 0]
         velocity_c = velocity_c - tmp_flux * flux + rdyc * (ke[0, -1, 0] - ke)
 


### PR DESCRIPTION
Changes:
- Adds `namelist` and `grid` automatically to all stencil externals. To use this, add `from __externals__ import grid, namelist`.
- Changes `if` conditions to asserts.

This is necessary without this PR: https://github.com/GridTools/gt4py/pull/204, since we decided to not merge it for now into GT4Py.

Note that the python files containing stencils do not need to import `spec.namelist`, since the decorator does that