### PR TITLE
Fix Fill4Corners test for GT backends

### DIFF
--- a/tests/translate/translate_fill4corners.py
+++ b/tests/translate/translate_fill4corners.py
@@ -1,4 +1,3 @@
-import fv3core.utils.gt4py_utils as utils
 from fv3core.utils import corners
 
 from .translate import TranslateFortranData2Py
@@ -12,8 +11,8 @@ class TranslateFill4Corners(TranslateFortranData2Py):
         self.out_vars = {"q4c": {}}
 
     def compute(self, inputs):
-        inputs["q4c"] = utils.make_storage_data(inputs["q4c"], inputs["q4c"].shape)
+        self.make_storage_data_input_vars(inputs)
         corners.fill_4corners(
             inputs["q4c"], "x" if inputs["dir"] == 1 else "y", self.grid
         )
-        return {"q4c": inputs["q4c"]}
+        return self.slice_output(inputs, {"q4c": inputs["q4c"]})


### PR DESCRIPTION
This PR modifies `translate_fill4corners.py` to transform the input data from a `numpy.ndarray` to a `gt.storage` before calling the compute method.