### PR TITLE
Change `MPI.Datatype` hint to `Any`

### DIFF
--- a/fv3core/utils/future_stencil.py
+++ b/fv3core/utils/future_stencil.py
@@ -147,7 +147,7 @@ class StencilTable(object, metaclass=Singleton):
 
         self._comm.Barrier()
 
-    def _get_target(self, node_id: int = -1) -> Tuple[int, int, MPI.Datatype]:
+    def _get_target(self, node_id: int = -1) -> Tuple[int, int, Any]:
         if node_id < 0:
             node_id = self._node_id
         return (node_id * self._buffer_size, self._buffer_size, self._mpi_type)


### PR DESCRIPTION
## Purpose

This PR fixes a bug in `future_stencil` that resulted from using `MPI.Datatype` as a type hint, which only works if `mpi4py` is installed. Changing this to `Any` resolves the issue since `fv3core` should be able to run without MPI.

Remove the sections below which do not apply.

## Code changes:

- Change `future_stencil.StencilTable._get_target` type hint from `MPI.Datatype` to `Any`

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
