### PR TITLE
Improve the translate tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ def backend(pytestconfig):
 def pytest_addoption(parser):
     parser.addoption("--backend", action="store", default="numpy")
     parser.addoption("--which_modules", action="store")
+    parser.addoption("--which_rank", action="store")
     parser.addoption("--skip_modules", action="store")
     parser.addoption("--print_failures", action="store_true")
     parser.addoption("--failure_stride", action="store", default=1)

--- a/tests/savepoint/conftest.py
+++ b/tests/savepoint/conftest.py
@@ -438,9 +438,6 @@ def get_parallel_mock_param(
     max_call_count,
     only_one_rank,
 ):
-    if only_one_rank is not None:
-        raise RuntimeError("Cannot use --which_rank with parallel tests.")
-
     return pytest.param(
         testobj,
         case.test_name,

--- a/tests/savepoint/test_translate.py
+++ b/tests/savepoint/test_translate.py
@@ -35,11 +35,8 @@ def compare_arr(computed_data, ref_data):
 
 def compare_scalar(computed_data: np.float64, ref_data: np.float64) -> np.float64:
     """Smooth error near zero values. Scalar versions."""
-    denom = np.abs(ref_data) + np.abs(computed_data)
-    if denom == 0:
-        return np.float64(0.0)
-    else:
-        return 2.0 * np.abs(computed_data - ref_data) / denom
+    err_as_array = compare_arr(np.atleast_1d(computed_data), np.atleast_1d(ref_data))
+    return err_as_array[0]
 
 
 def success_array(
@@ -122,29 +119,20 @@ def sample_wherefail(
             )
 
     # Determine worst result
-    worst_err = 0
-    worst_idx = 0
-    worst_full_idx = 0
-    for b in range(0, bad_indices_count, failure_stride):
-        err = compare_scalar(computed_failures[b], reference_failures[b])
-        if worst_err < err:
-            worst_err = err
-            worst_idx = b
-            worst_full_idx = [f[b] for f in found_indices]
+    err = compare_arr(computed_data, ref_data)
+    worst_full_idx = np.unravel_index(np.argmax(err, axis=None), err.shape)
 
     # Summary and worst result
     fullcount = len(ref_data.flatten())
-    absolute_err = abs(computed_failures[worst_idx] - reference_failures[worst_idx])
-    metric_err = compare_scalar(
-        computed_failures[worst_idx], reference_failures[worst_idx]
-    )
+    abs_err = abs(computed_data[worst_full_idx] - ref_data[worst_full_idx])
+    metric_err = compare_scalar(computed_data[worst_full_idx], ref_data[worst_full_idx])
     return_strings.append(
         f"Failed count: {bad_indices_count}/{fullcount} "
         f"({round(100.0 * (bad_indices_count / fullcount), 2)}%),\n"
         f"Worst failed index {worst_full_idx}\n"
-        f"\tcomputed:{computed_failures[worst_idx]}\n"
-        f"\treference: {reference_failures[worst_idx]}\n"
-        f"\tabsolute diff: {absolute_err:.3e}\n"
+        f"\tcomputed:{computed_data[worst_full_idx]}\n"
+        f"\treference: {ref_data[worst_full_idx]}\n"
+        f"\tabsolute diff: {abs_err:.3e}\n"
         f"\tmetric diff: {metric_err:.3e}\n"
     )
 


### PR DESCRIPTION

## Purpose

Adds `--which_rank` in translate pytest and  verbose errors (adding the metric error)

## Code changes:

* `--which_rank`: only run one rank of the test (check all variables)
* Prints the metric error calculated in `compare_arr` which differs from an absolute error. Restrict print to 3 decimal in scientific notation

## Requirements changes:

N/A

## Infrastructure changes:

N/A

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [x] Unit tests are added or updated for non-stencil code changes