### PR TITLE
Fix illegal memory errors

### DIFF
--- a/fv3core/stencils/fillz.py
+++ b/fv3core/stencils/fillz.py
@@ -20,7 +20,7 @@ def fix_tracer(
     sum1: FloatFieldIJ,
 ):
     # reset fields
-    with computation(FORWARD), interval(0, 1):
+    with computation(FORWARD), interval(...):
         zfix = 0
         sum0 = 0.0
         sum1 = 0.0

--- a/fv3core/stencils/neg_adj3.py
+++ b/fv3core/stencils/neg_adj3.py
@@ -92,7 +92,7 @@ def fix_negative_liq(qvapor, qice, qsnow, qgraupel, qrain, qliquid, pt, lcpk, ic
 
 
 def fillq(q: FloatField, dp: FloatField, sum1: FloatFieldIJ, sum2: FloatFieldIJ):
-    with computation(FORWARD), interval(0, 1):
+    with computation(FORWARD), interval(...):
         # reset accumulating fields
         sum1 = 0.0
         sum2 = 0.0


### PR DESCRIPTION
## Purpose

This PR reverts the two k-interval reductions in `fillq` and `fillz` stencils from the `fix/perf-tweaks` branch (PR #610) as it causes intermittent illegal memory errors with the `gtc:gt:gpu` backend.

## Code changes:

- Change 2D field initialization block in `fillq` interval from (0,1) to ...
- Change 2D field initialization block in `fix_tracer` interval from (0,1) to ...

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
