### PR TITLE
Fetching caches also in run_standalone

### DIFF
--- a/.jenkins/actions/fetch_caches.sh
+++ b/.jenkins/actions/fetch_caches.sh
@@ -15,7 +15,6 @@ if [ ! -d $(pwd)/.gt_cache ]; then
         if [ "$version" == "$GT4PY_VERSION" ]; then
             if [ -d ${CACHE_DIR}/${EXPNAME}/${SANITIZED_BACKEND}/.gt_cache  ]; then
                 cp -r ${CACHE_DIR}/${EXPNAME}/${SANITIZED_BACKEND}/.gt_cache .
-                find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$SANITIZED_BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
                 find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/gtc_cache_setup\/backend\/${SANITIZED_BACKEND}\/experiment\/${EXPNAME}\/slave\/daint_submit|$(pwd)|g" {} +
             fi
         fi

--- a/.jenkins/actions/run_cached_fv_dynamics.sh
+++ b/.jenkins/actions/run_cached_fv_dynamics.sh
@@ -17,7 +17,6 @@ if [ ! -d $(pwd)/.gt_cache ]; then
     fi
     if [ "$version" == "$GT4PY_VERSION" ]; then
         cp -r /scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$EXPNAME/$SANITIZED_BACKEND/.gt_cache* .
-        find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$SANITIZED_BACKEND\/experiment\/$EXPNAME\/slave\/daint_submit|$(pwd)|g" {} +
         find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/gtc_cache_setup\/backend\/${SANITIZED_BACKEND}\/experiment\/${EXPNAME}\/slave\/daint_submit|$(pwd)|g" {} +
     fi
 fi

--- a/.jenkins/actions/run_standalone.sh
+++ b/.jenkins/actions/run_standalone.sh
@@ -108,6 +108,11 @@ echo "Perf. artifact directory:     ${TIMING_DIR}"
 echo "Profile artifact directory:   ${PROFILE_DIR}"
 echo "Cache directory:              ${CACHE_DIR}"
 
+
+if [ -z "${GT4PY_VERSION}" ]; then
+    export GT4PY_VERSION=`cat GT4PY_VERSION.txt`
+fi
+
 # If the backend is a GTC backend we fetch the caches
 if [[ $backend != *numpy* ]];then
     . ${ROOT_DIR}/.jenkins/actions/fetch_caches.sh $backend $experiment

--- a/examples/standalone/benchmarks/run_on_daint.sh
+++ b/examples/standalone/benchmarks/run_on_daint.sh
@@ -77,7 +77,9 @@ cd $ROOT_DIR
 make update_submodules_venv
 # set GT4PY version
 cd $ROOT_DIR
-export GT4PY_VERSION=`cat GT4PY_VERSION.txt`
+if [ -z "${GT4PY_VERSION}" ]; then
+    export GT4PY_VERSION=`cat GT4PY_VERSION.txt`
+fi
 
 # set up the virtual environment
 echo "creating the venv"
@@ -119,22 +121,23 @@ split_path=(${data_path//\// })
 experiment=${split_path[-1]}
 sample_cache=.gt_cache
 
-echo "Attempting to use precomputed cache"
-if [ ! -d $(pwd)/${sample_cache} ] ; then
-    premade_caches=/scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$sanitized_backend
-    if [ -d ${premade_caches}/${sample_cache} ] ; then
-	    version_file=${premade_caches}/GT4PY_VERSION.txt
-	    if [ -f ${version_file} ]; then
-            version=`cat ${version_file}`
-	    else
-            version=""
-	    fi
-	    if [ "$version" == "$GT4PY_VERSION" ]; then
-	        echo "Copying premade GT4Py caches"
-            cp -r ${premade_caches}/.gt_cache* .
-            find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/fv3core-cache-setup\/backend\/$sanitized_backend\/experiment\/$experiment\/slave\/daint_submit|$(pwd)|g" {} +
-	    fi
-   fi
+if [ ! -d $(pwd)/.gt_cache ]; then
+    echo "Attempting to use precomputed cache"
+    if [ ! -d $(pwd)/${sample_cache} ] ; then
+        premade_caches=/scratch/snx3000/olifu/jenkins/scratch/store_gt_caches/$experiment/$sanitized_backend
+        if [ -d ${premade_caches}/${sample_cache} ] ; then
+            version_file=${premade_caches}/GT4PY_VERSION.txt
+            if [ -f ${version_file} ]; then
+                version=`cat ${version_file}`
+            else
+                version=""
+            fi
+            if [ "$version" == "$GT4PY_VERSION" ]; then
+                cp -r ${premade_caches}/.gt_cache .
+                find . -name m_\*.py -exec sed -i "s|\/scratch\/snx3000\/olifu\/jenkins_submit\/workspace\/gtc_cache_setup\/backend\/${SANITIZED_BACKEND}\/experiment\/${EXPNAME}\/slave\/daint_submit|$(pwd)|g" {} +
+            fi
+        fi
+    fi
 fi
 
 echo "Submitting script to do performance run"


### PR DESCRIPTION
## Purpose

With the caches that are generated from the gtc backends the `run_standalone` script no longer works as it does not go through `.jenkins/jenkins.sh` in all use-cases. This PR adds the fetching of caches also if the standalone runs directly.

## Code changes:

- Addition of a fetch caches command for non-numpy runs in `run_standalone`

## Checklist
Before submitting this PR, please make sure:

- [X] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [X] Docstrings and type hints are added to new and updated routines, as appropriate
- [X] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [X] Unit tests are added or updated for non-stencil code changes
