### PR TITLE
Using the normal queue for long ranks for a lot of ranks

### DIFF
--- a/.jenkins/jenkins.sh
+++ b/.jenkins/jenkins.sh
@@ -127,8 +127,10 @@ if grep -q "parallel" <<< "${script}"; then
 	if [ -f ${scheduler_script} ] ; then
 	    sed -i 's|<NTASKS>|<NTASKS>\n#SBATCH \-\-hint=multithread\n#SBATCH --ntasks-per-core=2|g' ${scheduler_script}
 	    sed -i 's|45|30|g' ${scheduler_script}
-	    if [ "$NUM_RANKS" -gt "6" ];then
+	    if [ "$NUM_RANKS" -gt "6" ] && [ ! -v LONG_EXECUTION ]; then
             sed -i 's|cscsci|debug|g' ${scheduler_script}
+        elif [ "$NUM_RANKS" -gt "6" ]; then
+            sed -i 's|cscsci|normal|g' ${scheduler_script}
         fi
 	    sed -i 's|<NTASKS>|"'${NUM_RANKS}'"|g' ${scheduler_script}
 	    sed -i 's|<NTASKSPERNODE>|"24"|g' ${scheduler_script}


### PR DESCRIPTION
## Purpose

Currently we chose to run parallel tests in two categories:
- Less or equal to 6 ranks: use the `cscsci` queue
- Use more than 6 ranks: use the `debug` queue
This causes a problem when we use the `LONG_EXECUTION` mode where we allocate jobs for 3:30 in case a rebuild is needed as this fits neither queue if we use more than 6 ranks. 
This PR addresses that problem.

## Code changes:

- Change the sed logic in `.jenkins/jenkins.sh` to use the normal queue in case of long execution and more than 6 ranks

## Checklist
Before submitting this PR, please make sure:

- [X] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [X] Docstrings and type hints are added to new and updated routines, as appropriate
- [X] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [X] Unit tests are added or updated for non-stencil code changes
