### PR TITLE
add Split to NullComm

### DIFF
--- a/tests/main/test_null_comm.py
+++ b/tests/main/test_null_comm.py
@@ -1,0 +1,14 @@
+import fv3gfs.util
+from fv3core.utils.null_comm import NullComm
+
+
+def test_can_create_cube_communicator():
+    rank = 2
+    total_ranks = 24
+    mpi_comm = NullComm(rank, total_ranks)
+    layout = (2, 2)
+    partitioner = fv3gfs.util.CubedSpherePartitioner(
+        fv3gfs.util.TilePartitioner(layout)
+    )
+    communicator = fv3gfs.util.CubedSphereCommunicator(mpi_comm, partitioner)
+    communicator.tile.partitioner


### PR DESCRIPTION
## Purpose

Adds Split method to NullComm. Necessary to initialize CubedSphereCommunicators.

## Code changes:

- Added Split method to NullComm

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)
- [ ] Unit tests are added or updated for non-stencil code changes
