### PR TITLE
update intents in fxadv docstring

### DIFF
--- a/fv3core/stencils/fxadv.py
+++ b/fv3core/stencils/fxadv.py
@@ -507,10 +507,10 @@ class FiniteVolumeFluxPrep:
         Args:
             uc: covariant x-velocity on the C-grid (in)
             vc: covariant y-velocity on the C-grid (in)
-            crx: Courant number, x direction(inout)
-            cry: Courant number, y direction(inout)
-            x_area_flux: flux of area in x-direction, in units of m^2 (inout)
-            y_area_flux: flux of area in y-direction, in units of m^2 (inout)
+            crx: Courant number, x direction (out)
+            cry: Courant number, y direction (out)
+            x_area_flux: flux of area in x-direction, in units of m^2 (out)
+            y_area_flux: flux of area in y-direction, in units of m^2 (out)
             uc_contra: contravariant x-velocity on C-grid (out)
             vc_contra: contravariant y-velocity on C-grid (out)
             dt: acoustic timestep in seconds


### PR DESCRIPTION
## Purpose

Some output variables in FiniteVolumeFluxPrep were incorrectly indicated as inouts. This PR updates their intents in the docstring.

## Checklist
Before submitting this PR, please make sure:

- [x] You have followed the coding standards guidelines established at [Code Review Checklist](https://paper.dropbox.com/doc/Code-Review-Checklist--BD7zigBMAhMZAPkeNENeuU2UAg-IlsYffZgTwyKEylty7NhY).
- [x] Docstrings and type hints are added to new and updated routines, as appropriate
- [x] All relevant documentation has been updated or added (e.g. README, CONTRIBUTING docs)